### PR TITLE
changed Demo3 button text to 'Follow me'

### DIFF
--- a/src/components/Demos.js
+++ b/src/components/Demos.js
@@ -167,7 +167,7 @@ export function Demo3() {
 						<SVGGitHub style={{ width: px(19), height: px(19) }} /* strokeWidth={2.25} */ />
 						&nbsp;&nbsp;
 						<span>
-							Follow on Twitter
+							Follow me!
 						</span>
 					</span>
 				</p>


### PR DESCRIPTION
Issue #15 Changed the demo button text to the following: "Follow me!"

Current look
![image](https://user-images.githubusercontent.com/47023801/94983209-35790b80-0506-11eb-8ac8-3d6e466efde2.png)
